### PR TITLE
Graph copy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,4 +190,4 @@ ignore = [
 # HATCH_BUILD_HOOKS_ENABLE = "1"
 
 [tool.typos.default] 
-extend-ignore-identifiers-re = ["(?i)nd2?.*", "(?i)ome"]
+extend-ignore-identifiers-re = ["(?i)nd2?.*", "(?i)ome", "whis"]

--- a/src/micromanager_gui/_plate_viewer/_analysis.py
+++ b/src/micromanager_gui/_plate_viewer/_analysis.py
@@ -48,7 +48,6 @@ from ._util import (
     _WaitingProgressBarWidget,
     calculate_dff,
     create_stimulation_mask,
-    get_cubic_phase,
     get_iei,
     get_linear_phase,
     get_overlap_roi_with_stimulated_area,
@@ -836,11 +835,9 @@ class _AnalyseCalciumTraces(QWidget):
         # get the conditions for the well
         condition_1, condition_2 = self._get_conditions(fov_name)
 
-        # get the linear and cubic phase of the peaks in the dec_dff trace
-        linear_phase, cubic_phase = [], []
+        linear_phase = []
         if len(peaks_dec_dff) > 0:
             linear_phase = get_linear_phase(timepoints, peaks_dec_dff)
-            cubic_phase = get_cubic_phase(timepoints, peaks_dec_dff)
 
         # if the elapsed time is not available or for any reason is different from
         # the number of timepoints, set it as list of timepoints every exp_time
@@ -867,8 +864,7 @@ class _AnalyseCalciumTraces(QWidget):
             condition_2=condition_2,
             total_recording_time_in_sec=tot_time_sec,
             active=len(peaks_dec_dff) > 0,
-            linear_phase=linear_phase,
-            cubic_phase=cubic_phase,
+            instantaneous_phase=linear_phase,
             iei=iei,
             stimulated=roi_stimulation_overlap_ratio > STIMULATION_AREA_THRESHOLD,
         )

--- a/src/micromanager_gui/_plate_viewer/_graph_widgets.py
+++ b/src/micromanager_gui/_plate_viewer/_graph_widgets.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 RED = "#C33"
 HEIGHT = 20
 RANDOM_CHOICE = 5
-SEPARATOR = "\n"
+SEPARATOR = "_"
 
 
 def _get_fov_data(

--- a/src/micromanager_gui/_plate_viewer/_plate_viewer.py
+++ b/src/micromanager_gui/_plate_viewer/_plate_viewer.py
@@ -264,15 +264,15 @@ class PlateViewer(QMainWindow):
         self._set_splitter_sizes()
 
         # TO REMOVE, IT IS ONLY TO TEST________________________________________________
-        data = r"/Volumes/T7 Shield/LAM77_NC240503_384_CBD_20240927/NC240503_240927_Treated_CBDanalogs.tensorstore.zarr"
-        self._labels_path = (
-            r"/Volumes/T7 Shield/LAM77_NC240503_384_CBD_20240927/test_label"
-        )
-        self._analysis_files_path = (
-            r"/Volumes/T7 Shield/LAM77_NC240503_384_CBD_20240927/test_graphs"
-        )
-        reader = TensorstoreZarrReader(data)
-        self._init_widget(reader)
+        # data = r"/Volumes/T7 Shield/LAM77_NC240503_384_CBD_20240927/NC240503_240927_Treated_CBDanalogs.tensorstore.zarr" # noqa: E501
+        # self._labels_path = (
+        #     r"/Volumes/T7 Shield/LAM77_NC240503_384_CBD_20240927/test_label"
+        # )
+        # self._analysis_files_path = (
+        #     r"/Volumes/T7 Shield/LAM77_NC240503_384_CBD_20240927/test_graphs"
+        # )
+        # reader = TensorstoreZarrReader(data)
+        # self._init_widget(reader)
         # ____________________________________________________________________________
 
     @property

--- a/src/micromanager_gui/_plate_viewer/_plate_viewer.py
+++ b/src/micromanager_gui/_plate_viewer/_plate_viewer.py
@@ -264,11 +264,15 @@ class PlateViewer(QMainWindow):
         self._set_splitter_sizes()
 
         # TO REMOVE, IT IS ONLY TO TEST________________________________________________
-        # data = "/Users/fdrgsp/Desktop/t/ts.tensorstore.zarr"
-        # self._labels_path = "/Users/fdrgsp/Desktop/test/ts_labels"
-        # self._analysis_files_path = "/Users/fdrgsp/Desktop/test/ts_analysis"
-        # reader = TensorstoreZarrReader(data)
-        # self._init_widget(reader)
+        data = r"/Volumes/T7 Shield/LAM77_NC240503_384_CBD_20240927/NC240503_240927_Treated_CBDanalogs.tensorstore.zarr"
+        self._labels_path = (
+            r"/Volumes/T7 Shield/LAM77_NC240503_384_CBD_20240927/test_label"
+        )
+        self._analysis_files_path = (
+            r"/Volumes/T7 Shield/LAM77_NC240503_384_CBD_20240927/test_graphs"
+        )
+        reader = TensorstoreZarrReader(data)
+        self._init_widget(reader)
         # ____________________________________________________________________________
 
     @property

--- a/src/micromanager_gui/_plate_viewer/_plot_methods/__init__.py
+++ b/src/micromanager_gui/_plate_viewer/_plot_methods/__init__.py
@@ -1,3 +1,7 @@
-from ._main_plot import plot_multi_well_data, plot_single_well_data
+from ._main_plot import (
+    plot_multi_cond_data,
+    plot_multi_well_data,
+    plot_single_well_data,
+)
 
-__all__ = ["plot_multi_well_data", "plot_single_well_data"]
+__all__ = ["plot_multi_cond_data", "plot_multi_well_data", "plot_single_well_data"]

--- a/src/micromanager_gui/_plate_viewer/_plot_methods/_main_plot.py
+++ b/src/micromanager_gui/_plate_viewer/_plot_methods/_main_plot.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from micromanager_gui._plate_viewer._util import (
+    CELL_SIZE_ALL,
     DEC_DFF,
     DEC_DFF_AMPLITUDE,
     DEC_DFF_AMPLITUDE_VS_FREQUENCY,
@@ -21,9 +22,13 @@ from micromanager_gui._plate_viewer._util import (
     STIMULATED_AREA,
     STIMULATED_ROIS,
     STIMULATED_ROIS_WITH_STIMULATED_AREA,
+    SYNCHRONY_ALL,
 )
 
-from ._multi_wells_plots._multi_well_data_plot import _plot_multi_well_data
+from ._multi_wells_plots._multi_well_data_plot import (
+    _plot_multi_cond_data,
+    _plot_multi_well_data,
+)
 from ._single_wells_plots._raster_plots import _generate_raster_plot
 from ._single_wells_plots._single_well_data import _plot_single_well_data
 from ._single_wells_plots._stimulation_plots import _visualize_stimulated_area
@@ -61,6 +66,8 @@ MULTI_WELL_GRAPHS_OPTIONS: dict[str, dict[str, bool]] = {
     DEC_DFF_AMPLITUDE: {"amp": True},
     DEC_DFF_FREQUENCY: {"freq": True},
     DEC_DFF_IEI: {"iei": True},
+    CELL_SIZE_ALL: {"cell_size": True},
+    SYNCHRONY_ALL: {"sync": True},
 }
 
 
@@ -118,7 +125,7 @@ def plot_multi_well_data(
     widget: _MultilWellGraphWidget,
     text: str,
     data: dict[str, dict[str, ROIData]],
-    positions: list[int] | None = None,
+    # positions: list[int] | None = None,
 ) -> None:
     """Plot the multi-well data."""
     if not text or text == "None" or not data:
@@ -126,6 +133,22 @@ def plot_multi_well_data(
 
     # get the options for the text using the MULTI_WELL_GRAPHS_OPTIONS dictionary that
     # maps the text to the options
-    return _plot_multi_well_data(
-        widget, data, positions, **MULTI_WELL_GRAPHS_OPTIONS[text]
+    return _plot_multi_well_data(widget, data, **MULTI_WELL_GRAPHS_OPTIONS[text])
+
+
+def plot_multi_cond_data(
+    widget: _MultilWellGraphWidget,
+    text: str,
+    data: dict[str, list[ROIData]],
+    cond_order: list[str],
+    plate_map_color: dict[str, str],
+) -> None:
+    """Plot the multi-well data."""
+    if not text or text == "None" or not data:
+        return
+
+    # get the options for the text using the MULTI_WELL_GRAPHS_OPTIONS dictionary that
+    # maps the text to the options
+    return _plot_multi_cond_data(
+        widget, data, cond_order, plate_map_color, **MULTI_WELL_GRAPHS_OPTIONS[text]
     )

--- a/src/micromanager_gui/_plate_viewer/_plot_methods/_multi_wells_plots/_multi_well_data_plot.py
+++ b/src/micromanager_gui/_plate_viewer/_plot_methods/_multi_wells_plots/_multi_well_data_plot.py
@@ -194,7 +194,11 @@ def _plot_multi_cond_data(
         #     sync_idx = get_connectivity(phase_dict)
         #     dp_list.append(sync_idx)
 
-    data_list = [dp_dict[cond] for cond in cond_ordered]
+    data_list, final_cond = [], []
+    for cond in cond_ordered:
+        if cond in dp_dict:
+            data_list.append(dp_dict[cond])
+            final_cond.append(cond)
 
     # violin plot
     # ax.violinplot(data_list)
@@ -202,7 +206,7 @@ def _plot_multi_cond_data(
     #   labels=cond_ordered)
 
     # boxplot
-    ax.boxplot(data_list, tick_labels=cond_ordered, whis=(0, 100))
+    ax.boxplot(data_list, tick_labels=final_cond, whis=(0, 100))
 
     _set_axis_labels(ax, amp, freq, iei, cell_size, sync, cell_size_unit)
 

--- a/src/micromanager_gui/_plate_viewer/_plot_methods/_multi_wells_plots/_multi_well_data_plot.py
+++ b/src/micromanager_gui/_plate_viewer/_plot_methods/_multi_wells_plots/_multi_well_data_plot.py
@@ -4,7 +4,11 @@ from typing import TYPE_CHECKING
 
 import mplcursors
 
+# from micromanager_gui._plate_viewer._util import get_connectivity
+
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
     from micromanager_gui._plate_viewer._graph_widgets import _MultilWellGraphWidget
     from micromanager_gui._plate_viewer._util import ROIData
 
@@ -18,10 +22,12 @@ NON_STIMULATED_COLOR = "magenta"
 def _plot_multi_well_data(
     widget: _MultilWellGraphWidget,
     data: dict[str, dict[str, ROIData]],
-    positions: list[int] | None = None,
+    # positions: list[int] | None = None,
     amp: bool = False,
     freq: bool = False,
     iei: bool = False,
+    cell_size: bool = False,
+    sync: bool = False,
 ) -> None:
     """Plot the multi-well data."""
     widget.figure.clear()
@@ -31,9 +37,6 @@ def _plot_multi_well_data(
     wells_names: list[str] = []
     # loop over the data and plot the data
     for well_and_fov, roi_data in data.items():
-        if positions is not None and int(well_and_fov) not in positions:
-            continue
-
         # this is to store the well names to then use them as x axis labels
         if (well := well_and_fov.split("_")[0]) not in wells_names:
             wells_names.append(well)
@@ -93,8 +96,20 @@ def _plot_multi_well_data(
                 ax.set_xlabel("Wells")
                 ax.set_ylabel("Inter-event intervals (sec)")
 
+            elif cell_size:
+                if r_data.cell_size is None:
+                    continue
+                ax.plot(
+                    well_count,
+                    r_data.cell_size,
+                    "o",
+                    label=f"{well_and_fov} - roi{roi}",
+                )
+                ax.set_xlabel("Wells")
+                ax.set_ylabel(f"Cell Size ({r_data.cell_size_units})")
+
     # set ticks labels as well names
-    if (amp or freq or iei) and not (amp and freq):
+    if (amp or freq or iei or cell_size) and not (amp and freq):
         ax.set_xticks(range(1, len(wells_names) + 1))
         ax.set_xticklabels(wells_names)
 
@@ -108,3 +123,117 @@ def _plot_multi_well_data(
         sel.annotation.set(text=sel.artist.get_label(), fontsize=8, color="black")
 
     widget.canvas.draw()
+
+
+def _plot_multi_cond_data(
+    widget: _MultilWellGraphWidget,
+    data: dict[str, list[ROIData]],
+    cond_ordered: list[str],
+    plate_map_color: dict[str, str],
+    amp: bool = False,
+    freq: bool = False,
+    iei: bool = False,
+    cell_size: bool = False,
+    sync: bool = False,
+) -> None:
+    """Make plots based on conditions selected."""
+    widget.figure.clear()
+    ax = widget.figure.add_subplot(111)
+
+    dp_dict: dict[str, list[float]] = {}
+
+    for cond, roi_data in data.items():
+        # well = well_and_fov.split("_")[0]
+        # if cond_sel is not None and well not in cond_sel:
+        #     continue
+
+        if cond not in dp_dict:
+            dp_dict[cond] = []
+
+        # phase_dict: dict[str, list[float]] = {}
+        cell_size_unit: str | None = None
+
+        # use condition 1 as x-axis if any else use cond 2
+        for r_data in roi_data:
+            # r_data = roi_data[roi]
+
+            if amp:
+                if r_data.peaks_amplitudes_dec_dff is None:
+                    continue
+
+                dp_dict[cond] += r_data.peaks_amplitudes_dec_dff
+
+            elif freq:
+                if r_data.dec_dff_frequency is None:
+                    continue
+
+                dp_dict[cond].append(r_data.dec_dff_frequency)
+
+            elif iei:
+                if r_data.iei is None:
+                    continue
+
+                dp_dict[cond] += r_data.iei
+
+            elif cell_size:
+                if r_data.cell_size is None:
+                    continue
+
+                dp_dict[cond].append(r_data.cell_size)
+                cell_size_unit = r_data.cell_size_units
+
+        #     elif synchrony:
+        #         if (
+        #             r_data.linear_phase is None
+        #         ):
+        #             continue
+
+        #         phase_dict[roi] = r_data.linear_phase
+
+        # if len(phase_dict.keys()) > 0:
+        #     sync_idx = get_connectivity(phase_dict)
+        #     dp_list.append(sync_idx)
+
+    data_list = [dp_dict[cond] for cond in cond_ordered]
+
+    # violin plot
+    # ax.violinplot(data_list)
+    # ax.set_xticks([y + 1 for y in range(len(cond_ordered))],
+    #   labels=cond_ordered)
+
+    # boxplot
+    ax.boxplot(data_list, tick_labels=cond_ordered, whis=(0, 100))
+
+    _set_axis_labels(ax, amp, freq, iei, cell_size, sync, cell_size_unit)
+
+    widget.figure.tight_layout()
+
+    widget.canvas.draw()
+
+
+def _set_axis_labels(
+    ax: Axes,
+    amp: bool,
+    freq: bool,
+    iei: bool,
+    cell_size: bool,
+    sync: bool,
+    cell_size_unit: str | None,
+) -> None:
+    """Set axis labels based on the plotted data."""
+    if amp:
+        ax.set_xlabel("Conditions")
+        ax.set_ylabel("Amplitude")
+    elif freq:
+        ax.set_xlabel("Conditions")
+        ax.set_ylabel("Frequency")
+    elif iei:
+        ax.set_xlabel("Conditions")
+        ax.set_ylabel("Inter-event intervals (sec)")
+    elif cell_size:
+        ax.set_xlabel("Conditions")
+        y_axis = f"Cell Size ({cell_size_unit})" if cell_size_unit else "Cell Size"
+        ax.set_ylabel(y_axis)
+    elif sync:
+        ax.set_xlabel("Conditions")
+        ax.set_ylabel("Global synchrony")

--- a/src/micromanager_gui/_plate_viewer/_util.py
+++ b/src/micromanager_gui/_plate_viewer/_util.py
@@ -128,8 +128,7 @@ class ROIData(BaseClass):
     cell_size_units: str | None = None
     total_recording_time_in_sec: float | None = None
     active: bool | None = None
-    linear_phase: list[float] | None = None
-    cubic_phase: list[float] | None = None
+    instantaneous_phase: list[float] | None = None
     iei: list[float] | None = None  # interevent interval
     stimulated: bool = False
     # ... add whatever other data we need

--- a/src/micromanager_gui/_plate_viewer/_util.py
+++ b/src/micromanager_gui/_plate_viewer/_util.py
@@ -53,6 +53,7 @@ DEC_DFF_FREQUENCY = "Deconvolved DeltaF/F0 Frequencies"
 DEC_DFF_AMPLITUDE_VS_FREQUENCY = "Deconvolved DeltaF/F0 Amplitudes vs Frequencies"
 DEC_DFF_IEI = "Deconvolved DeltaF/F0 Inter-event Interval"
 
+CELL_SIZE_ALL = "Cell sizes"
 DEC_DFF_AMPLITUDE_VS_FREQUENCY_ALL = "Deconvolved DeltaF/F0 Amplitudes vs Frequencies"
 DEC_DFF_AMPLITUDE_ALL = "Deconvolved DeltaF/F0 Amplitudes"
 DEC_DFF_FREQUENCY_ALL = "Deconvolved DeltaF/F0 Frequencies"
@@ -65,6 +66,7 @@ STIMULATED_ROIS = "Stimulated vs Non-Stimulated ROIs"
 STIMULATED_ROIS_WITH_STIMULATED_AREA = (
     "Stimulated vs Non-Stimulated ROIs with Stimulated Area"
 )
+SYNCHRONY_ALL = "Global Synchrony"
 
 SINGLE_WELL_COMBO_OPTIONS = [
     RAW_TRACES,
@@ -88,10 +90,12 @@ SINGLE_WELL_COMBO_OPTIONS = [
 ]
 
 MULTI_WELL_COMBO_OPTIONS = [
+    CELL_SIZE_ALL,
     DEC_DFF_AMPLITUDE_VS_FREQUENCY_ALL,
     DEC_DFF_AMPLITUDE_ALL,
     DEC_DFF_FREQUENCY_ALL,
     DEC_DFF_IEI_ALL,
+    SYNCHRONY_ALL,
 ]
 # ------------------------------------------------------------------------------------
 


### PR DESCRIPTION
I messed up the original graph branch by merging other branches into it. So this is a cleaner version of #57 

COPY of the description from #57 
-------------------------------------------
Built upon fdrgsp/micromanager-gui: micromanager-gui-calcium

## What is this branch?
Add the function in the multi-well graph to visualize multiple wells/conditions for cell size, amplitude, frequencies, and IEI. (Synchrony will be added soon.)

## Walkthrough:
There are several scenarios where the user wants to visualize different things:
### 1. Look at all the wells in the plate with single ROIs plotted. 
- In this case, the user can choose the type of plot directly without checking the `choose which well(s)/condition(s) to display', and the program will plot all the ROI data. 
- Note: The program might be very slow or even crash if the user tries to hover over each ROI data to get the label. 
<img width="2240" alt="Screenshot 2025-03-28 at 2 20 29 PM" src="https://github.com/user-attachments/assets/600735a5-1419-439c-ab46-b0fdbe0dbbb3" />

### 2. Look at wells/conditions of interest.
- In this case, the user should check the `choose which well(s)/condition(s) to display`.
- After checking `choose which well(s)/condition(s) to display`, the program will populate a list of conditions based on the platemap(s) that the user made/loaded in the `analysis tab`.
#### 2.1. random wells
- If the user presses `update` without putting in any well name, the program will pick 5 random wells to display.

<img width="2240" alt="Screenshot 2025-03-28 at 2 26 41 PM" src="https://github.com/user-attachments/assets/88ab85c0-395a-448b-aae2-235c508891f8" />

#### 2.2. Wells of interest
- The user can type in the well name (e.g., B2, C10, F11, etc.). The program will display the single-cell data from all ROIs in each chosen well. The hover function is implemented.
<img width="2240" alt="Screenshot 2025-03-28 at 2 28 49 PM" src="https://github.com/user-attachments/assets/ecd52f14-b14a-43c4-a977-1049fedaa92d" />

#### 2.3. Conditions of interest
- The user can also choose to visualize the conditions. The program will plot the single-cell data from all ROIs in all the wells in each chosen condition (not taking the average of a FOV or a well) in a boxplot with whisker range from 0-100 (i.e., not detecting outliers). 
- If the user chooses conditions from genotype (`COND1`) OR treatment (`COND2`) (or that one plate map is missing), the program will display all wells in that condition. 
- If the user chooses conditions from genotype (`COND1`) AND treatment (`COND2`), the program will display the wells that match both conditions. 
Note: The order in which the user chooses the conditions determines the order of the boxplots.
<img width="2240" alt="Screenshot 2025-03-28 at 2 34 52 PM" src="https://github.com/user-attachments/assets/78db8f64-7f97-4f6a-bbe8-2a28093bdada" />

Note: if no platemap is loaded, then the program will display random wells. 

